### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ AdaptiveCode
 
 Code samples to accompany the book Adaptive Code Via C#.
 
-##Build Status
+## Build Status
 ![Build Status](https://ci.appveyor.com/api/projects/status/github/garymcleanhall/AdaptiveCode)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
